### PR TITLE
fixes for OS X soft links

### DIFF
--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/GitRepository.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/GitRepository.scala
@@ -1,6 +1,8 @@
 package com.softwaremill.codebrag.repository
 
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ResetCommand.ResetType
+import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.transport.{URIish, CredentialItem, UsernamePasswordCredentialsProvider, CredentialsProvider}
 import com.softwaremill.codebrag.repository.config.{RepoData, UserPassCredentials, PassphraseCredentials}
 
@@ -22,13 +24,14 @@ class GitRepository(val repoData: RepoData) extends Repository with RepositoryAu
   protected def pullChangesForRepo() {
     val git = new Git(repo)
     val fetchCommand = git.fetch().setRemoveDeletedRefs(true) // need co call fetch first as pull doesn't have an option to purge removed branches
-    val pullCommand = git.pull()
+    val updateCommand = git.reset()
+        .setMode(ResetType.HARD)
+        .setRef(Constants.FETCH_HEAD)
     credentialsProvider.foreach { p =>
       fetchCommand.setCredentialsProvider(p)
-      pullCommand.setCredentialsProvider(p)
     }
     fetchCommand.call()
-    pullCommand.call()
+    updateCommand.call()
   }
 
   private class SshPassphraseCredentialsProvider(passphrase: String) extends CredentialsProvider {

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/Repository.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/Repository.scala
@@ -1,17 +1,15 @@
 package com.softwaremill.codebrag.repository
 
-import com.typesafe.scalalogging.slf4j.Logging
-import org.eclipse.jgit.lib.{ObjectId, Constants}
-import org.eclipse.jgit.revwalk.{RevWalk, RevCommit}
-import org.eclipse.jgit.storage.file.FileRepository
-import org.eclipse.jgit.errors.MissingObjectException
 import com.softwaremill.codebrag.repository.config.RepoData
-import org.eclipse.jgit.api.Git
+import com.typesafe.scalalogging.slf4j.Logging
+import org.eclipse.jgit.errors.MissingObjectException
+import org.eclipse.jgit.lib.{Constants, ObjectId}
+import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
 
 trait Repository extends Logging with RepositorySnapshotLoader with RepositoryDeltaLoader with BranchesModel {
 
   def repoData: RepoData
-  def repo: FileRepository
+  def repo: org.eclipse.jgit.lib.Repository
   val repoName = repoData.repoName
 
   def pullChanges() {

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/commits/jgit/JgitDiffExtractor.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/commits/jgit/JgitDiffExtractor.scala
@@ -39,7 +39,7 @@ trait JgitDiffExtractor {
       }
     }
     finally {
-      formatter.release()
+      formatter.close()
     }
   }
 
@@ -73,7 +73,7 @@ trait JgitDiffExtractor {
       newTreeId
     }
     finally {
-      inserter.release()
+      inserter.close()
     }
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,8 +109,8 @@ object Dependencies {
   val bson = "org.mongodb" % "bson" % "2.7.1"
 
   val egitGithubApi = "org.eclipse.mylyn.github" % "org.eclipse.egit.github.core" % "2.1.3"
-  val jGit = "org.eclipse.jgit" % "org.eclipse.jgit" % "2.3.1.201302201838-r"
-  val jsch = "com.jcraft" % "jsch" % "0.1.51"
+  val jGit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.2.0.201601211800-r"
+  val jsch = "com.jcraft" % "jsch" % "0.1.53"
   val dispatch = "net.databinder.dispatch" %% "dispatch-core" % "0.9.5"
 
   val slick = "com.typesafe.slick" %% "slick" % "2.0.3"


### PR DESCRIPTION
These fix an issue with jgit updates not deleting soft links correctly on OS X which was leaving the local repo with uncommited changes