### PR TITLE
Reset the repository before rebasing it. 

### DIFF
--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/GitSvnRepository.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/GitSvnRepository.scala
@@ -7,6 +7,7 @@ import com.softwaremill.codebrag.repository.config.{RepoData, UserPassCredential
 
 class GitSvnRepository(val repoData: RepoData) extends Repository with RepositoryAutoBuilder with GitSvnBranchesModel {
 
+  private val CommandBaseReset = "git reset --hard"
   private val CommandBase = "git svn rebase --quiet"
 
   protected def pullChangesForRepo() {
@@ -15,6 +16,7 @@ class GitSvnRepository(val repoData: RepoData) extends Repository with Repositor
 
   private def runPullCommand() {
     val repoPath = Paths.get(repoData.repoLocation)
+    Process(CommandBaseReset, repoPath.toFile) !< ProcessLogger(logger info _)
     if(repoData.repoCredentials.isDefined) {
       repoData.repoCredentials.get match {
         case c: UserPassCredentials => runWithUserPassCredentials(repoPath, c)


### PR DESCRIPTION
When the repository has been modified (even if it shouldn't), simply doing a `git rebase --quiet` won't update the repository and a message of type `my.file : needs update` is generated by the command. The codebrag's UI will no more display new commits because the repository is not updated.
Adding a `git reset --hard` before the rebase ensure all changes are erased and the repository is clean again and the UI reflects the new changes again.