### PR TITLE
Adding the possibility to not pull changes for repositories for a given period and fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ H2 console
 When using the embedded SQL storage, it may be useful to browse the tables. H2 provides consoles, which can be run
 as follows:
 
-1. For a web console, run from sbt: `codebrag-dao/run-h2-console`
+1. For a web console, run from sbt: `codebrag-dao/runH2Console`
 2. For a command line console, run `java -Dconfig.file=codebrag.conf -cp [path to the fat JAR] com.softwaremill.codebrag.dao.sql.H2ShellConsole`

--- a/codebrag-rest/src/main/resources/application.conf.template
+++ b/codebrag-rest/src/main/resources/application.conf.template
@@ -28,7 +28,7 @@ codebrag {
 
     # Period during within the repositories won't be fetch
     pull-sleep-period {
-        enabled = true
+        enabled = false
         from = 22
         to = 5
     }

--- a/codebrag-rest/src/main/resources/application.conf.template
+++ b/codebrag-rest/src/main/resources/application.conf.template
@@ -25,6 +25,13 @@ codebrag {
 
     # number of people who need to review a commit (1, 2, ..., all)
     required-reviewers-count = 1
+
+    # Period during within the repositories won't be fetch
+    pull-sleep-period {
+        enabled = true
+        from = 22
+        to = 5
+    }
 }
 
 email-notifications {

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/Repository.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/Repository.scala
@@ -10,19 +10,18 @@ import org.eclipse.jgit.errors.MissingObjectException
 import org.eclipse.jgit.lib.{Constants, ObjectId}
 import org.eclipse.jgit.revwalk.{RevCommit, RevWalk}
 
-trait Repository extends Logging with RepositorySnapshotLoader with RepositoryDeltaLoader with BranchesModel {
+trait Repository extends Logging with RepositorySnapshotLoader with RepositoryDeltaLoader with BranchesModel
+  with CodebragConfig {
 
+  def rootConfig: Config = ConfigFactory.load()
   def repoData: RepoData
   def repo: org.eclipse.jgit.lib.Repository
-  val repoName = repoData.repoName
-  val config: CodebragConfig = new CodebragConfig {
-    def rootConfig = ConfigFactory.load()
-  }
 
+  val repoName = repoData.repoName
   def pullChanges() {
-    logger.debug(s"Pulling changes for ${repoData.repoLocation}")
 
     if(canPullAtThisTime()) {
+      logger.debug(s"Pulling changes for ${repoData.repoLocation}")
       try {
         pullChangesForRepo()
         logger.debug(s"Changes pulled succesfully")
@@ -56,9 +55,9 @@ trait Repository extends Logging with RepositorySnapshotLoader with RepositoryDe
   protected def branchNameToSHA(objId: ObjectId) = ObjectId.toString(objId)
 
   protected def canPullAtThisTime(): Boolean = {
-    if(config.pullSleepPeriodEnabled) {
+    if(this.pullSleepPeriodEnabled) {
       val currentHour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
-      currentHour >= config.pullSleepPeriodEnd && currentHour < config.pullSleepPeriodStart
+      currentHour >= this.pullSleepPeriodEnd && currentHour < this.pullSleepPeriodStart
     } else {
       true
     }

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/Repository.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/repository/Repository.scala
@@ -1,6 +1,10 @@
 package com.softwaremill.codebrag.repository
 
+import java.util.Calendar
+
 import com.softwaremill.codebrag.repository.config.RepoData
+import com.softwaremill.codebrag.service.config.CodebragConfig
+import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.slf4j.Logging
 import org.eclipse.jgit.errors.MissingObjectException
 import org.eclipse.jgit.lib.{Constants, ObjectId}
@@ -11,17 +15,25 @@ trait Repository extends Logging with RepositorySnapshotLoader with RepositoryDe
   def repoData: RepoData
   def repo: org.eclipse.jgit.lib.Repository
   val repoName = repoData.repoName
+  val config: CodebragConfig = new CodebragConfig {
+    def rootConfig = ConfigFactory.load()
+  }
 
   def pullChanges() {
     logger.debug(s"Pulling changes for ${repoData.repoLocation}")
-    try {
-      pullChangesForRepo()
-      logger.debug(s"Changes pulled succesfully")
-    } catch {
-      case e: Exception => {
-        logger.error(s"Cannot pull changes for repo ${repoData.repoLocation} because of: ${e.getMessage}")
-        throw e
+
+    if(canPullAtThisTime()) {
+      try {
+        pullChangesForRepo()
+        logger.debug(s"Changes pulled succesfully")
+      } catch {
+        case e: Exception => {
+          logger.error(s"Cannot pull changes for repo ${repoData.repoLocation} because of: ${e.getMessage}")
+          throw e
+        }
       }
+    } else {
+      logger.debug("Current time configuration doesn't allow to pull changes.")
     }
   }
 
@@ -42,6 +54,15 @@ trait Repository extends Logging with RepositorySnapshotLoader with RepositoryDe
   protected def pullChangesForRepo()
 
   protected def branchNameToSHA(objId: ObjectId) = ObjectId.toString(objId)
+
+  protected def canPullAtThisTime(): Boolean = {
+    if(config.pullSleepPeriodEnabled) {
+      val currentHour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
+      currentHour >= config.pullSleepPeriodEnd && currentHour < config.pullSleepPeriodStart
+    } else {
+      true
+    }
+  }
 }
 
 object Repository {

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
@@ -17,6 +17,9 @@ trait CodebragConfig extends ConfigWithDefault with StatsConfig with EmailNotifi
 
   lazy val invitationExpiryTime: ReadablePeriod = Period.millis(getMilliseconds("codebrag.invitation-expiry-time", 24.hours.toMillis).toInt)
 
+  lazy val pullSleepPeriodEnabled = getBoolean("codebrag.pull-sleep-period.enabled", default = true)
+  lazy val pullSleepPeriodStart = getInt("codebrag.pull-sleep-period.from", 22)
+  lazy val pullSleepPeriodEnd = getInt("codebrag.pull-sleep-period.from", 5)
 }
 
 trait EmailNotificationConfig extends ConfigWithDefault {

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
@@ -19,7 +19,7 @@ trait CodebragConfig extends ConfigWithDefault with StatsConfig with EmailNotifi
 
   lazy val pullSleepPeriodEnabled = getBoolean("codebrag.pull-sleep-period.enabled", default = false)
   lazy val pullSleepPeriodStart = getInt("codebrag.pull-sleep-period.from", 22)
-  lazy val pullSleepPeriodEnd = getInt("codebrag.pull-sleep-period.from", 5)
+  lazy val pullSleepPeriodEnd = getInt("codebrag.pull-sleep-period.to", 5)
 }
 
 trait EmailNotificationConfig extends ConfigWithDefault {

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
@@ -17,13 +17,13 @@ trait CodebragConfig extends ConfigWithDefault with StatsConfig with EmailNotifi
 
   lazy val invitationExpiryTime: ReadablePeriod = Period.millis(getMilliseconds("codebrag.invitation-expiry-time", 24.hours.toMillis).toInt)
 
-  lazy val pullSleepPeriodEnabled = getBoolean("codebrag.pull-sleep-period.enabled", default = true)
+  lazy val pullSleepPeriodEnabled = getBoolean("codebrag.pull-sleep-period.enabled", default = false)
   lazy val pullSleepPeriodStart = getInt("codebrag.pull-sleep-period.from", 22)
   lazy val pullSleepPeriodEnd = getInt("codebrag.pull-sleep-period.from", 5)
 }
 
 trait EmailNotificationConfig extends ConfigWithDefault {
-  lazy val userNotifications: Boolean = getBoolean("email-notifications.enabled", default = true)
+  lazy val userNotifications: Boolean = getBoolean("email-notifications.enabled", default = false)
   lazy val notificationsCheckInterval = getMilliseconds("email-notifications.check-interval", 15.minutes.toMillis).millis
   lazy val userOfflinePeriod = Period.millis(getMilliseconds("email-notifications.user-offline-after", 5.minutes.toMillis).toInt)
 

--- a/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
+++ b/codebrag-service/src/main/scala/com/softwaremill/codebrag/service/config/CodebragConfig.scala
@@ -23,7 +23,7 @@ trait CodebragConfig extends ConfigWithDefault with StatsConfig with EmailNotifi
 }
 
 trait EmailNotificationConfig extends ConfigWithDefault {
-  lazy val userNotifications: Boolean = getBoolean("email-notifications.enabled", default = false)
+  lazy val userNotifications: Boolean = getBoolean("email-notifications.enabled", default = true)
   lazy val notificationsCheckInterval = getMilliseconds("email-notifications.check-interval", 15.minutes.toMillis).millis
   lazy val userOfflinePeriod = Period.millis(getMilliseconds("email-notifications.user-offline-after", 5.minutes.toMillis).toInt)
 


### PR DESCRIPTION
In order to save network bandwith as well as uneeded logs, the configuration of Codebrag gets enriched with a new parameter store in the `codebrag` block. This parameter is of the following form:

```
pull-sleep-period {
    enabled = true
    from = 22
    to = 5
}
```

This configuration says that Codebrag is allowed to not pull changes for repositories from 10PM to 4:59AM. If `enabled` is set to `false` then Codebrag will always pull changes.

This PR also fixes an error in the `README.md` : in order to run the H2 console from `sbt` we must call `codebrag-dao/runH2Console` and not `codebrag-dao/run-h2-console`.