### PR TITLE
gray-out deleted text a little in diff view

### DIFF
--- a/codebrag-ui/app/styles/common.styl
+++ b/codebrag-ui/app/styles/common.styl
@@ -139,7 +139,6 @@ table tr:nth-of-type(even)
 table tr th,
 table tr td
   font-size: 1em;
-  color: $body-text-color;
   padding: 0.23em 0.77em;
 
 // General styles

--- a/codebrag-ui/app/styles/diff.styl
+++ b/codebrag-ui/app/styles/diff.styl
@@ -186,6 +186,7 @@
 
   & tr.removed
     background: #ffdddd;
+    color: #cc9999;
 
     & .diff-line-num
       background: #f7c8c8;


### PR DESCRIPTION
makes code a little more readable - only existing text stays black.